### PR TITLE
modified mention of the IC socket polarity.

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -119,7 +119,7 @@ LEDs are a polarized component and therefore take care of direction, the short l
 
 Solder on the IC socket. 
 
-The IC socket is a polarized component, check the notch on silkscreen and IC Socket.
+The IC socket mounts a polarized component, check the notch on silkscreen and IC Socket.
 
 ![IC Socket](images/guide/ic-socket.jpg)
 
@@ -155,7 +155,7 @@ Used for programming the microprocessor with the bootloader directly. If your MC
 
 Insert ATMEGA328P into IC Socket.
 
-Ensure that you insert it in the correct orientation, the semicircular mark should match that of the IC socket.
+Ensure that you insert it in the correct orientation, the semicircular mark should match that of the silkscreen.
 
 ![ATMEGA328P](images/guide/atmega328p.jpg)
 


### PR DESCRIPTION
IC socket is not polar. Microcontroller is. The IC socket can be backwards as long as microprocessor is still oriented correctly compared to the pcb.